### PR TITLE
Make compatible with MediaWiki 1.39.0

### DIFF
--- a/NiceCategoryList.php
+++ b/NiceCategoryList.php
@@ -284,11 +284,9 @@ class NiceCategoryList {
  
         // convert results list into an array
         $list = array();
-        while ($x = $dbr->fetchObject($res))
+        foreach ($res as $x) {
                 $list[] = $x;
- 
-        // free the results
-        $dbr->freeResult($res);
+	}
  
         return $list;
     }


### PR DESCRIPTION
I had an issue with MediaWiki 1.39.0 with the plugin and needed to fix the database access. After looking at the docs (https://www.mediawiki.org/wiki/Manual:Database_access), the change seems to be correct, but please check yourself once again.